### PR TITLE
Add authentication and access control, as an abuse-mitigation mechanism.

### DIFF
--- a/app.py
+++ b/app.py
@@ -44,6 +44,7 @@
 
 from cadastre import sql
 from cadastre import config
+from cadastre import authn
 from cadastre import document
 
 # ## THE WEB APPLICATION
@@ -56,10 +57,12 @@ from cadastre import document
 
 from apistar import Include, Route
 from apistar.handlers import docs_urls, static_urls
+from cadastre import authn
 from cadastre import document
 
 routes = [
     Include('/document', document.routes),
+    Include('/user', authn.routes),
     Include('/docs', docs_urls),
     Include('/static', static_urls),
 ]
@@ -67,9 +70,11 @@ routes = [
 # The preceeding services also export components used to manipulate HTTP
 # requests and responses.
 
+from cadastre import authn
+from cadastre import document
 from cadastre import sql
 
-components = sql.components + document.components
+components = sql.components + authn.components + document.components
 
 # Finally, expose all of the endpoints, as well as supporting components, as an
 # API Star application. This can be bound to a WSGI framework and executed as a

--- a/cadastre/authn/__init__.py
+++ b/cadastre/authn/__init__.py
@@ -1,0 +1,201 @@
+# Some operations require that the client present an authentication token. This
+# is primarily to minimize abuse: by requiring a registration step, abusive
+# users can be located and their contributions to the registry identified.
+#
+# ## TERMINOLOGY
+#
+# A user is a person who has registered. A user is identified by their email
+# address. During the registration process, the person provides a password,
+# which can be used to generate one or more bearer tokens for API usage.
+#
+# ## PRINCIPLES
+#
+# This authentication system operates in two modes. When the user is present,
+# they can (and should) authenticate using their password. Password
+# authentication verifies the user based on a secret only they know.
+#
+# To ensure that users are not encouraged to write down passwords, automated use
+# of the API - including use through interactive tools - should use tokens,
+# instead. Tokens are ephemeral: new tokens can be minted for an account very
+# easily, and existing tokens invalidated quickly. This allows a user to take
+# fine-grained control over the tokens available at any give time: for example,
+# a token that has been leaked in logs or accidentally pasted can be invalidated
+# without also rotating every other credential tied to the account.
+#
+# Authentication credentials can be presented to the service in the following
+# ways:
+#
+# * Username and password credentials can be presented using HTTP Basic
+#   authentication.
+#
+# * Token credentials can be presented using HTTP Basic authentication with an
+#   empty username, or with a username exactly matching the token's owning user.
+#
+# * Token credentials can be presented using HTTP Bearer authentication.
+#
+# Certain API requests for managing tokens require username and password
+# credentials. This prevents an API token from being used to, for example,
+# change the user's password, or to issue new tokens that might then not be
+# invalidated when the original token is invalidated.
+#
+# ## ENDPOINTS
+
+# Registers a user. A person can call this endpoint to provide credentials. If
+# the email address is not already registered, this will succeed, and return an
+# initial API token for the user. If the email address is already registered,
+# this will return a 400 Bad Request error with an informative body.
+
+import apistar
+from apistar import typesystem, reverse_url
+from . import repository as repo
+
+class Email(typesystem.String):
+    format = 'email'
+    pattern = '.+@.+'
+
+class User(typesystem.Object):
+    properties = {
+        'email': Email,
+        'password': typesystem.string(min_length=8),
+        'token_description': typesystem.string(min_length=1),
+    }
+
+class Token(typesystem.Object):
+    properties = {
+        'id': typesystem.string(),
+        'description': typesystem.string(),
+        'token': typesystem.string(),
+        'url': typesystem.string(format='url'),
+    }
+
+def register_user(user: User, repository: repo.Repository) -> Token:
+    registered_user = repository.create_user(user['email'], user['password'])
+    token = registered_user.generate_token(user['token_description'])
+    return Token(
+        id=token.id,
+        description=token.description,
+        token=token.token,
+        url=reverse_url('revoke_token', id=token.id)
+    )
+
+# Changes a user's password. This is an interactive-only request - that the
+# requesting user knows their current password is necessary to prove that they
+# should be allowed to change it. This has no effect on outstanding API tokens.
+
+from apistar.interfaces import Auth
+from . import policy
+
+class PasswordChange(typesystem.Object):
+    properties = {
+        'password': typesystem.string(min_length=8),
+    }
+
+@policy.authenticated
+def change_password(request: PasswordChange, auth: Auth):
+    auth.user.update_password(request['password'])
+
+# Returns some basic information about the current user. This is primarily
+# intended to allow clients to correctly determine the logged-in user's email,
+# for use when prompting for passwords for interactive authentication. It can be
+# performed by any authenticated client, including clients using token
+# authentication.
+
+from apistar.interfaces import Auth
+from . import policy
+
+class WhoAmI(typesystem.Object):
+    properties = {
+        'email': Email,
+    }
+
+@policy.authenticated
+def whoami(auth: Auth) -> WhoAmI:
+    return WhoAmI(email = auth.user.email)
+
+# Lists active tokens for an existing user. Like all token management, this is
+# an interactive-only request. API tokens are not privileged to inspect one
+# another (or, even, themselves) and cannot be used to extend access.
+
+from apistar import reverse_url
+from apistar.interfaces import Auth
+import typing
+from . import policy
+
+@policy.interactive
+def tokens(auth: Auth) -> typing.List[Token]:
+    tokens = auth.user.tokens
+    return [
+        Token(
+            id=token.id,
+            description=token.description,
+            url=reverse_url('revoke_token', id=token.id)
+        )
+        for token in tokens
+    ]
+
+# Issues a new token for an existing user. Like all token management, this is an
+# interactive-only request. API tokens are not privileged to inspect one another
+# (or, even, themselves) and cannot be used to extend access.
+#
+# This can be used to implement a "login" flow, where the user exchanges their
+# password for an API token for the current client.
+
+from apistar import reverse_url
+from apistar.interfaces import Auth
+from . import policy
+
+class TokenRequest(typesystem.Object):
+    properties = {
+        'description': typesystem.string(min_length=1),
+    }
+
+@policy.interactive
+def issue_token(token_request: TokenRequest, auth: Auth) -> Token:
+    token = auth.user.generate_token(token_request['description'])
+    return Token(
+        id=token.id,
+        description=token.description,
+        token=token.token,
+        url=reverse_url('revoke_token', id=token.id),
+    )
+
+# Revokes a token for an existing user. This immediately and irreversibly
+# destroys the token: if the user wants to undo it, they must issue a new token.
+
+from apistar.interfaces import Auth
+from . import policy
+
+@policy.interactive
+def revoke_token(id, auth: Auth):
+    token = auth.user.revoke_token(id)
+
+# ## WEB APPLICATION CONFIGURATION
+
+# Users and authentication have a set of related API routes, which will all be
+# mounted together. The root of this collection is the submission endpoint for
+# creating and updating documents.
+
+from apistar import Route
+
+routes = [
+    Route('/', 'GET', whoami),
+    Route('/register', 'POST', register_user),
+    Route('/token', 'GET', tokens),
+    Route('/token', 'POST', issue_token),
+    Route('/token/{id}', 'DELETE', revoke_token),
+]
+
+# Users also include some helper components, which provide SQL access to user
+# storage. These components must be available in the application for the routes
+# defined in this chapter to function correctly.
+
+from . import repository as repo
+
+components = repo.components
+
+# Users also include an authentication policy system.
+
+from . import authenticator
+
+authentication = authenticator.all_authenticators
+

--- a/cadastre/authn/authenticator.py
+++ b/cadastre/authn/authenticator.py
@@ -1,0 +1,92 @@
+# Cadastre verifies credentials in one of three ways, as described at the root
+# of this section.
+
+# Username and password credentials can be presented using Basic authentication.
+# In this case, the returned auth object will have no token.
+
+import base64
+from apistar import http
+from apistar.authentication import Authenticated
+from . import repository as repo
+
+class BasicPasswordAuthentication():
+    def authenticate(self, authorization: http.Header, repository: repo.Repository):
+        if authorization is None:
+            return None
+
+        scheme, token = authorization.split(' ', 1)
+        if scheme.lower() != 'basic':
+            return None
+
+        username, password = base64.b64decode(token).decode('utf-8').split(':', 1)
+        user = repository.find_user(username)
+        if user is None:
+            return None
+
+        if user.validate_password(password):
+            return Authenticated(username, user = user, token = None)
+
+        return None
+
+# API token credentials can be presented using Basic authentication with an
+# empty username, or with a username exactly equal to the username associated
+# with the token. In this case, the returned auth object will include the token.
+
+import base64
+from apistar import http
+from apistar.authentication import Authenticated
+from . import repository as repo
+
+class BasicTokenAuthentication():
+    def authenticate(self, authorization: http.Header, repository: repo.Repository):
+        if authorization is None:
+            return None
+
+        scheme, token = authorization.split(' ', 1)
+        if scheme.lower() != 'basic':
+            return None
+
+        username, password = base64.b64decode(token).decode('utf-8').split(':', 1)
+        user = repository.find_token_user(password)
+        if user is None:
+            return None
+
+        if username != '' and username != user.email:
+            return None
+
+        return Authenticated(user.email, user = user, token = password)
+
+# API token credentials can be presented using Bearer authentication. In this
+# case, the returned auth object will include the token.
+
+from apistar import http
+from apistar.authentication import Authenticated
+from . import repository as repo
+
+class BearerTokenAuthentication():
+    def authenticate(self, authorization: http.Header, repository: repo.Repository):
+        if authorization is None:
+            return None
+
+        scheme, token = authorization.split(' ', 1)
+        if scheme.lower() != 'bearer':
+            return None
+
+        user = repository.find_token_user(token)
+        if user is None:
+            return None
+
+        user = repository.find_token_user(token)
+        if user is None:
+            return None
+
+        return Authenticated(user.email, user = user, token = token)
+
+# To apply authentication to an applicatio using this authentication policy, use
+# the following prefabricated list of authenticators.
+
+all_authenticators = [
+    BasicPasswordAuthentication(),
+    BasicTokenAuthentication(),
+    BearerTokenAuthentication(),
+]

--- a/cadastre/authn/policy.py
+++ b/cadastre/authn/policy.py
@@ -1,0 +1,41 @@
+# Authorization policies used in Cadastre follow one of a small number of
+# schemes.
+#
+# The default scheme allows any request, including unauthenticated requests. To
+# use this scheme, no additional code is required.
+
+# The Authenticated scheme requires that a user present any kind of valid
+# credential.
+from apistar.interfaces import Auth
+
+class Authenticated(object):
+    def has_permission(self, auth: Auth):
+        return auth.is_authenticated()
+
+# This scheme may be imposed on an API endpoint using the `@authenticated`
+# decorator.
+
+from apistar import annotate
+
+def authenticated(endpoint):
+    return annotate(
+        permissions=[Authenticated()]
+    )(endpoint)
+
+# The Interactive policy requires that a user present a password credential.
+# This restricts the operation such that API token clients cannot perform it.
+from apistar.interfaces import Auth
+
+class Interactive(object):
+    def has_permission(self, auth: Auth):
+        return auth.is_authenticated() and auth.token is None
+
+# This scheme may be imposed on an API endpoint using the `@interactive`
+# decorator.
+
+from apistar import annotate
+
+def interactive(endpoint):
+    return annotate(
+        permissions=[Interactive()]
+    )(endpoint)

--- a/cadastre/authn/repository.py
+++ b/cadastre/authn/repository.py
@@ -1,0 +1,173 @@
+# Storage for Cadastre authentication data records information necessary to
+# identify the user originating any given request. This stores three key facts
+# about each user:
+#
+# * Their login email address. This isn't actually validated - we don't send it
+#   mail to confirm it - but given the closed audience I don't expect that to be
+#   a source of trouble.
+#
+# * A bcrypt digest of their password. This is the user's primary credential. We
+#   assume that changing a password frequently and using unique passwords per
+#   site are both good ideas, but also that users will not actually do those
+#   things reliably. To protect users from these risks, passwords are stored
+#   digested so that a database dump (or a rogue administrator) cannot recover
+#   passwords for any practical amount of effort.
+#
+# * A set - possibly empty - of generated API tokens that are currently valid
+#   for the user. API tokens are credentials, but they're much more ephemeral
+#   than passwords. As we must be able to identify a user by token alone,
+#   they're stored in the clear; a database dump will contain all valid tokens
+#   at that point in time.
+#
+# In the event of a data disclosure event, such as a public database dump, it's
+# trivial to invalidate all existing tokens (by deleting them from the
+# underlying database) and to advise users to issue themselves new tokens using
+# their passwords. Because tokens are always generated on the service's side,
+# there are no meaningful risks that a user will have the same token on Cadastre
+# and on another service.
+
+# ## REPOSITORY
+
+# A repository handles storage and retrieval of users against an underlying data
+# store. A `Repository` wraps a specific SQLAlchemy Session, and should not
+# outlive it.
+
+import apistar.exceptions
+import bcrypt
+import sqlalchemy.exc
+
+# For development convenience, this directly converts to an HTTP response.
+class UserExistsError(apistar.exceptions.ValidationError):
+    pass
+
+class Repository(object):
+    def __init__(self, session):
+        self.session = session
+
+    # Submits a new user to this repository.
+    #
+    # In either case, the user model object used to represent the user will be
+    # returned.
+    #
+    # If the user already exists, this method raises a UserExistsError.
+    def create_user(self, email, password):
+        password_digest = digest_password(password)
+        user = User(
+            email=email,
+            password_digest=password_digest,
+        )
+        try:
+            self.session.add(user)
+            self.session.flush([user]) # Ensure we raise an exception immediately if the user exists.
+            return user
+        except sqlalchemy.exc.IntegrityError as e:
+            raise UserExistsError from e
+
+    # Find an existing user by email address. Used to support username
+    # authentication and as an entrypoint into token management. Returns None if
+    # no user exists with the requested email.
+    def find_user(self, email):
+        return self.session.query(User).filter(User.email == email).one_or_none()
+
+    # Find an existing user by API token. Used to support token authentication.
+    # Returns None if no user exists with the requested token.
+    def find_token_user(self, token):
+        return self.session.query(User).join(ApiToken).filter(ApiToken.token == token).one_or_none()
+
+# Encodes and digests a password.
+def digest_password(password):
+    password = password.encode('UTF-8')
+    password_salt = bcrypt.gensalt()
+    password_digest = bcrypt.hashpw(password, password_salt)
+    return password_digest
+
+# ## MODELS
+
+# A User holds the email address and password credential for a user.
+
+import bcrypt
+from cadastre import sql
+from sqlalchemy import Column, String, LargeBinary
+from sqlalchemy.orm import relationship, backref, Session
+import uuid
+
+class User(sql.Base):
+    __tablename__ = 'user'
+    email = Column(String, primary_key = True)
+    password_digest = Column(LargeBinary, nullable = False)
+
+    tokens = relationship('ApiToken',
+        backref=backref('user'),
+        collection_class=set,
+    )
+
+    # Checks a password against the stored password.
+    def validate_password(self, candidate):
+        candidate = candidate.encode('UTF-8')
+        return bcrypt.checkpw(candidate, self.password_digest)
+
+    # Change the stored password for this user.
+    def update_password(self, password):
+        self.password_digest = digest_password(password)
+
+    # Generate and store a new API token for this user. Returns the token.
+    def generate_token(self, description):
+        id = uuid.uuid4()
+        token = uuid.uuid4()
+        stored_token = ApiToken(
+            id = id,
+            email = self.email,
+            token = token,
+            description = description,
+        )
+        self.tokens.add(stored_token)
+        return stored_token
+
+    # Revoke a token by deleting it from the underlying data store
+    def revoke_token(self, id):
+        # I tried implementing this as operations on self.tokens, but SQLAlchemy
+        # tried to translate my code by unsetting ApiToken.email (which isn't
+        # correct, or what I wanted). This is kind of ugly, but it dispatches
+        # the right delete query.
+        session = Session.object_session(self)
+        # The email join is technically redundant since id is a primary key, but
+        # it never hurts to be specific about the join condition.
+        session.\
+            query(ApiToken).\
+            filter(ApiToken.email == self.email).\
+            filter(ApiToken.id == id).\
+            delete()
+
+# An ApiToken holds a bearer credential for a user. A user may have multiple
+# bearer credentials.
+
+from cadastre import sql
+
+from sqlalchemy import Column, String, ForeignKey
+
+class ApiToken(sql.Base):
+    __tablename__ = 'api_token'
+    id = Column(String, primary_key = True)
+    email = Column(String,
+        ForeignKey('user.email'),
+        nullable = False,
+    )
+    token = Column(String, unique = True, nullable = False)
+    description = Column(String, nullable = False)
+
+
+# ## COMPONENTS
+
+# The repository for a request can be made available as a component, relying on
+# the SQLAlchemy session component for the same request.
+
+from apistar.backends.sqlalchemy_backend import Session
+
+def request_repository(session: Session):
+    return Repository(session)
+
+from apistar import Component
+
+components = [
+    Component(Repository, init = request_repository, preload = False),
+]

--- a/cadastre/config.py
+++ b/cadastre/config.py
@@ -32,10 +32,12 @@ class Env(environment.Environment):
 # migrations, run the `bin/release` script.
 
 from . import sql
+from . import authn
 
 env = Env()
 
 settings = {
+    'AUTHENTICATION': authn.authentication,
     'DATABASE': {
         'URL': env['DATABASE_URL'],
         'METADATA': sql.Base.metadata,

--- a/database/versions/7dee6999be64_guarantee_token_uniqueness.py
+++ b/database/versions/7dee6999be64_guarantee_token_uniqueness.py
@@ -1,0 +1,24 @@
+"""guarantee token uniqueness
+
+Revision ID: 7dee6999be64
+Revises: 976d3e5450a4
+Create Date: 2017-10-09 16:28:59.484669
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '7dee6999be64'
+down_revision = '976d3e5450a4'
+branch_labels = None
+depends_on = None
+
+# This is in a separate revision from the migration that creates api_token as
+# the missing constraint was not discuvered until _after_ that revision had been
+# deployed to staging. Creating a separate revision ensures that the final DB
+# includes both, without any need for manual repair on staging.
+
+def upgrade():
+    op.create_unique_constraint('api_token_token', 'api_token', ['token'])

--- a/database/versions/976d3e5450a4_create_user_schema.py
+++ b/database/versions/976d3e5450a4_create_user_schema.py
@@ -1,0 +1,38 @@
+"""create user schema
+
+Revision ID: 976d3e5450a4
+Revises: d79d6a413e52
+Create Date: 2017-10-08 16:26:18.804600
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '976d3e5450a4'
+down_revision = 'd79d6a413e52'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'user',
+        sa.Column('email', sa.String, primary_key = True),
+        sa.Column('password_digest', sa.LargeBinary, nullable = False),
+    )
+
+    op.create_table(
+        'api_token',
+        sa.Column('id', sa.String, primary_key = True),
+        sa.Column('email', sa.String, sa.ForeignKey('user.email'), nullable = False),
+        sa.Column('token', sa.String, nullable = False),
+        sa.Column('description', sa.String, nullable = False),
+    )
+
+    op.create_index('api_token_email', 'api_token', ['email'])
+
+    op.add_column('revision',
+        sa.Column('submitter', sa.String, sa.ForeignKey('user.email')),
+    )

--- a/database/versions/d79d6a413e52_create_document_and_revision_schema.py
+++ b/database/versions/d79d6a413e52_create_document_and_revision_schema.py
@@ -47,8 +47,3 @@ def upgrade():
         deferrable = True,
         initially = 'DEFERRED',
     )
-
-
-def downgrade():
-    op.drop_table('document')
-    op.drop_table('revision')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,10 @@
 alembic==0.9.5
-apistar==0.3.0
+apistar==0.3.9
+bcrypt==3.1.3
 certifi==2017.7.27.1
+cffi==1.11.1
 chardet==3.0.4
-coreapi==2.3.1
+coreapi==2.3.3
 coreschema==0.0.4
 gunicorn==19.7.1
 idna==2.6
@@ -12,7 +14,8 @@ Mako==1.0.7
 MarkupSafe==1.0
 psycopg2==2.7.3.1
 py==1.4.34
-pytest==3.2.2
+pycparser==2.18
+pytest==3.2.3
 python-dateutil==2.6.1
 python-editor==1.0.3
 requests==2.18.4
@@ -21,4 +24,4 @@ SQLAlchemy==1.1.14
 uritemplate==3.0.0
 urllib3==1.22
 Werkzeug==0.12.2
-whitenoise==3.3.0
+whitenoise==3.3.1


### PR DESCRIPTION
1. This reduces the ability of spammers to use the archive to host their
  content. Registration is a low bar, but it's high enough to reduce the risk.

2. This allows content submitted by abusive users to be identified. Removal and
  cleanup is manual, but at least the information is recorded.