### PR TITLE
Require interactive authn for password changes, not just any authn.

### DIFF
--- a/cadastre/authn/__init__.py
+++ b/cadastre/authn/__init__.py
@@ -90,7 +90,7 @@ class PasswordChange(typesystem.Object):
         'password': typesystem.string(min_length=8),
     }
 
-@policy.authenticated
+@policy.interactive
 def change_password(request: PasswordChange, auth: Auth):
     auth.user.update_password(request['password'])
 


### PR DESCRIPTION
Fixes #5.